### PR TITLE
Update bundle identifier

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>bundleid</key>
-	<string>com.alfredapp.src.resize</string>
+	<string>app.alfredapp.stephenc.resize</string>
 	<key>category</key>
 	<string>Universal Action</string>
 	<key>connections</key>
@@ -12,7 +12,7 @@
 		<array>
 			<dict>
 				<key>destinationuid</key>
-				<string>CD3C707E-E13B-4899-A98A-16B760CFD873</string>
+				<string>1F5758E6-F709-47A7-AAAF-4C5EA492F29C</string>
 				<key>modifiers</key>
 				<integer>0</integer>
 				<key>modifiersubtext</key>
@@ -37,13 +37,64 @@
 			</dict>
 			<dict>
 				<key>destinationuid</key>
-				<string>CD3C707E-E13B-4899-A98A-16B760CFD873</string>
+				<string>1F5758E6-F709-47A7-AAAF-4C5EA492F29C</string>
 				<key>modifiers</key>
 				<integer>0</integer>
 				<key>modifiersubtext</key>
 				<string></string>
 				<key>sourceoutputuid</key>
 				<string>_button2</string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
+		<key>1F5DDD00-454A-4279-B8B4-E2C25763E34B</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>2B4BDF7E-0922-46B1-B5E9-F8EF143190A6</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>sourceoutputuid</key>
+				<string>4115022D-29DB-492C-B310-CEB76D68153E</string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+			<dict>
+				<key>destinationuid</key>
+				<string>5E27671A-7A50-4DAE-BA1E-B11661B50D57</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
+		<key>2B4BDF7E-0922-46B1-B5E9-F8EF143190A6</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>7F1CC430-1046-4A73-AEB0-D2E71CEB1D08</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
+		<key>3E57E9FF-6F48-4C36-BB6E-088B3CBF86D6</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>4FFD4BD5-3857-4901-A5EA-77938654A685</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
 				<key>vitoclose</key>
 				<false/>
 			</dict>
@@ -65,6 +116,19 @@
 		<array>
 			<dict>
 				<key>destinationuid</key>
+				<string>BBC10D8D-1F7A-423D-948C-B53AA74BD0D0</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
+		<key>5E27671A-7A50-4DAE-BA1E-B11661B50D57</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
 				<string>4FFD4BD5-3857-4901-A5EA-77938654A685</string>
 				<key>modifiers</key>
 				<integer>0</integer>
@@ -79,6 +143,19 @@
 			<dict>
 				<key>destinationuid</key>
 				<string>B9C873E7-5CD9-48C1-A548-A8D1426FCF13</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
+		<key>7F1CC430-1046-4A73-AEB0-D2E71CEB1D08</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>3E57E9FF-6F48-4C36-BB6E-088B3CBF86D6</string>
 				<key>modifiers</key>
 				<integer>0</integer>
 				<key>modifiersubtext</key>
@@ -113,29 +190,15 @@
 				<false/>
 			</dict>
 		</array>
-		<key>CD3C707E-E13B-4899-A98A-16B760CFD873</key>
+		<key>BBC10D8D-1F7A-423D-948C-B53AA74BD0D0</key>
 		<array>
 			<dict>
 				<key>destinationuid</key>
-				<string>B94CD7E2-56D2-484C-9606-C96693CE37EB</string>
+				<string>1F5DDD00-454A-4279-B8B4-E2C25763E34B</string>
 				<key>modifiers</key>
 				<integer>0</integer>
 				<key>modifiersubtext</key>
 				<string></string>
-				<key>sourceoutputuid</key>
-				<string>_button1</string>
-				<key>vitoclose</key>
-				<false/>
-			</dict>
-			<dict>
-				<key>destinationuid</key>
-				<string>FE15CA00-F80F-42BC-88F8-D4AF594C231C</string>
-				<key>modifiers</key>
-				<integer>0</integer>
-				<key>modifiersubtext</key>
-				<string></string>
-				<key>sourceoutputuid</key>
-				<string>_button2</string>
 				<key>vitoclose</key>
 				<false/>
 			</dict>
@@ -145,19 +208,6 @@
 			<dict>
 				<key>destinationuid</key>
 				<string>13F43189-880D-43E0-96D2-3F61F0094ABE</string>
-				<key>modifiers</key>
-				<integer>0</integer>
-				<key>modifiersubtext</key>
-				<string></string>
-				<key>vitoclose</key>
-				<false/>
-			</dict>
-		</array>
-		<key>FE15CA00-F80F-42BC-88F8-D4AF594C231C</key>
-		<array>
-			<dict>
-				<key>destinationuid</key>
-				<string>3DD4A818-A36E-430B-BAEC-EA019513C898</string>
 				<key>modifiers</key>
 				<integer>0</integer>
 				<key>modifiersubtext</key>
@@ -229,6 +279,55 @@
 		<dict>
 			<key>config</key>
 			<dict>
+				<key>tasksettings</key>
+				<dict/>
+				<key>taskuid</key>
+				<string>com.alfredapp.automation.core/files-and-folders/directory.new</string>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.automation.task</string>
+			<key>uid</key>
+			<string>7F1CC430-1046-4A73-AEB0-D2E71CEB1D08</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>argument</key>
+				<string>{var:theInput}</string>
+				<key>passthroughargument</key>
+				<false/>
+				<key>variables</key>
+				<dict/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.utility.argument</string>
+			<key>uid</key>
+			<string>3E57E9FF-6F48-4C36-BB6E-088B3CBF86D6</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>argument</key>
+				<string>{var:tempFolder}</string>
+				<key>passthroughargument</key>
+				<false/>
+				<key>variables</key>
+				<dict/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.utility.argument</string>
+			<key>uid</key>
+			<string>2B4BDF7E-0922-46B1-B5E9-F8EF143190A6</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
 				<key>json</key>
 				<string>{
   "alfredworkflow" : {
@@ -251,60 +350,14 @@
 			<key>config</key>
 			<dict>
 				<key>tasksettings</key>
-				<dict>
-					<key>max_size</key>
-					<string>{var:longestSide}</string>
-				</dict>
+				<dict/>
 				<key>taskuid</key>
-				<string>com.alfredapp.automation.core/image-manipulation/image.resize.longest-side</string>
+				<string>com.alfredapp.automation.core/files-and-folders/path.exists</string>
 			</dict>
 			<key>type</key>
 			<string>alfred.workflow.automation.task</string>
 			<key>uid</key>
-			<string>B9C873E7-5CD9-48C1-A548-A8D1426FCF13</string>
-			<key>version</key>
-			<integer>1</integer>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
-				<key>path</key>
-				<string>{var:tempFolder}</string>
-				<key>sortBy</key>
-				<integer>1</integer>
-				<key>sortDirection</key>
-				<integer>0</integer>
-				<key>sortFoldersAtTop</key>
-				<false/>
-				<key>sortOverride</key>
-				<true/>
-				<key>stackBrowserView</key>
-				<false/>
-			</dict>
-			<key>type</key>
-			<string>alfred.workflow.action.browseinalfred</string>
-			<key>uid</key>
-			<string>B94CD7E2-56D2-484C-9606-C96693CE37EB</string>
-			<key>version</key>
-			<integer>1</integer>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
-				<key>tasksettings</key>
-				<dict>
-					<key>overwrite</key>
-					<true/>
-					<key>save_in</key>
-					<string>{var:tempFolder}</string>
-				</dict>
-				<key>taskuid</key>
-				<string>com.alfredapp.automation.core/files-and-folders/finder.copy</string>
-			</dict>
-			<key>type</key>
-			<string>alfred.workflow.automation.task</string>
-			<key>uid</key>
-			<string>4FFD4BD5-3857-4901-A5EA-77938654A685</string>
+			<string>BBC10D8D-1F7A-423D-948C-B53AA74BD0D0</string>
 			<key>version</key>
 			<integer>1</integer>
 		</dict>
@@ -331,6 +384,96 @@
 		<dict>
 			<key>config</key>
 			<dict>
+				<key>tasksettings</key>
+				<dict>
+					<key>max_size</key>
+					<string>{var:longestSide}</string>
+				</dict>
+				<key>taskuid</key>
+				<string>com.alfredapp.automation.core/image-manipulation/image.resize.longest-side</string>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.automation.task</string>
+			<key>uid</key>
+			<string>B9C873E7-5CD9-48C1-A548-A8D1426FCF13</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>tasksettings</key>
+				<dict>
+					<key>overwrite</key>
+					<true/>
+					<key>save_in</key>
+					<string>{var:tempFolder}</string>
+				</dict>
+				<key>taskuid</key>
+				<string>com.alfredapp.automation.core/files-and-folders/finder.copy</string>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.automation.task</string>
+			<key>uid</key>
+			<string>4FFD4BD5-3857-4901-A5EA-77938654A685</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>conditions</key>
+				<array>
+					<dict>
+						<key>inputstring</key>
+						<string></string>
+						<key>matchcasesensitive</key>
+						<false/>
+						<key>matchmode</key>
+						<integer>6</integer>
+						<key>matchstring</key>
+						<string></string>
+						<key>outputlabel</key>
+						<string>No</string>
+						<key>uid</key>
+						<string>4115022D-29DB-492C-B310-CEB76D68153E</string>
+					</dict>
+				</array>
+				<key>elselabel</key>
+				<string>Yes</string>
+				<key>hideelse</key>
+				<false/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.utility.conditional</string>
+			<key>uid</key>
+			<string>1F5DDD00-454A-4279-B8B4-E2C25763E34B</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>argument</key>
+				<string>{var:tempFolder}</string>
+				<key>passthroughargument</key>
+				<false/>
+				<key>variables</key>
+				<dict>
+					<key>theInput</key>
+					<string>{query}</string>
+				</dict>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.utility.argument</string>
+			<key>uid</key>
+			<string>5462DD99-202D-4CCF-9168-ACDE888A771D</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
 				<key>button1</key>
 				<string>Save image to clipboard</string>
 				<key>button2</key>
@@ -346,26 +489,6 @@
 			<string>alfred.workflow.utility.dialog</string>
 			<key>uid</key>
 			<string>1BAFEBBB-8446-4B95-97ED-6D8E37116D89</string>
-			<key>version</key>
-			<integer>1</integer>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
-				<key>argument</key>
-				<string></string>
-				<key>passthroughargument</key>
-				<true/>
-				<key>variables</key>
-				<dict>
-					<key>theInput</key>
-					<string>{query}</string>
-				</dict>
-			</dict>
-			<key>type</key>
-			<string>alfred.workflow.utility.argument</string>
-			<key>uid</key>
-			<string>5462DD99-202D-4CCF-9168-ACDE888A771D</string>
 			<key>version</key>
 			<integer>1</integer>
 		</dict>
@@ -394,66 +517,39 @@
 			<key>config</key>
 			<dict>
 				<key>button1</key>
-				<string>Delete original</string>
+				<string>End the workflow</string>
 				<key>button2</key>
-				<string>Keep original</string>
+				<string></string>
 				<key>button3</key>
 				<string></string>
 				<key>description</key>
-				<string>The new file is in its original folder.
+				<string>{var:theInput} has been resized and is in its original folder.
 
-The original file is in {var:tempFolder} in case you still need it.
-
-(If you choose to delete you will browse in Alfred then use the right arrow key to select to delete the file.)</string>
+The original image is in {var:tempFolder}.  If you have not changed the default in the User Configuration the backup will be deleted when your Mac restarts.</string>
 				<key>title</key>
-				<string>Do you want to delete the original file?</string>
+				<string>Reduce size of JPEG/PNG image</string>
 			</dict>
 			<key>type</key>
 			<string>alfred.workflow.utility.dialog</string>
 			<key>uid</key>
-			<string>CD3C707E-E13B-4899-A98A-16B760CFD873</string>
+			<string>1F5758E6-F709-47A7-AAAF-4C5EA492F29C</string>
 			<key>version</key>
 			<integer>1</integer>
 		</dict>
 		<dict>
 			<key>config</key>
 			<dict>
-				<key>lastpathcomponent</key>
-				<true/>
-				<key>onlyshowifquerypopulated</key>
+				<key>argument</key>
+				<string>{var:theInput}</string>
+				<key>passthroughargument</key>
 				<false/>
-				<key>removeextension</key>
-				<false/>
-				<key>text</key>
-				<string>{query} has been resized to {var:longestSide}px on the longest side. The original image is in {var:tempFolder}.</string>
-				<key>title</key>
-				<string>File resized and original preserved</string>
+				<key>variables</key>
+				<dict/>
 			</dict>
 			<key>type</key>
-			<string>alfred.workflow.output.notification</string>
+			<string>alfred.workflow.utility.argument</string>
 			<key>uid</key>
-			<string>3DD4A818-A36E-430B-BAEC-EA019513C898</string>
-			<key>version</key>
-			<integer>1</integer>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
-				<key>json</key>
-				<string>{
-  "alfredworkflow" : {
-    "arg" : "{var:theInput}",
-    "config" : {
-    },
-    "variables" : {
-    }
-  }
-}</string>
-			</dict>
-			<key>type</key>
-			<string>alfred.workflow.utility.json</string>
-			<key>uid</key>
-			<string>FE15CA00-F80F-42BC-88F8-D4AF594C231C</string>
+			<string>5E27671A-7A50-4DAE-BA1E-B11661B50D57</string>
 			<key>version</key>
 			<integer>1</integer>
 		</dict>
@@ -465,10 +561,17 @@ This workflow, which works as a Universal Action on a single, selected JPEG or P
 
 - saves the *original* image in a temporary folder specified in the User Configuration;
 - resizes the image file to the default longest side measurement specified in the User Configuration (measured in pixels);
-- optionally allows saving of the resized image to the clipboard;
-- at the end of the workflow provides an option to delete the saved original image.
+- optionally allows saving of the resized image to the clipboard.
 
 **Note**: The workflow does *not* enlarge images that already have a shorter longer side than specified in the User Configuration.
+
+# Important note
+
+If you use the default backup folder in the User Configuration the backup is to a temporary folder which is:
+- automatically created if it does not exist; and
+- *automatically deleted when your Mac restarts*.
+
+*If you need to retrieve a backup you must move it from that default temporary folder before your Mac restarts*.
 
 # Usage
 
@@ -477,7 +580,15 @@ Select a single JPEG or PNG file in Finder, use your Universal Actions hotkey an
 ![Reduce size of JPEG/PNG file](Images/SelectedFile.png)
 
 # Credit
-The icon is provided under the [Creative Commons Attribution 3.0 Unported licence](https://creativecommons.org/licenses/by/3.0/legalcode) courtesy of ferdi setiadi.</string>
+The icon is provided under the [Creative Commons Attribution 3.0 Unported licence](https://creativecommons.org/licenses/by/3.0/legalcode) courtesy of ferdi setiadi.
+
+--- 
+
+**Version 2.0** 27/11/2022: now checks for existence of the temporary folder and warns user if not created. Updated Readme to emphasise need to create temporary folder before running workflow.
+
+**Version 3.0** 27/11/2022: with credit to @Vítor Galvão, backup is now to a tmp folder which is automatically deleted on reboot.
+
+**Version 3.1** 05/01/2023: updated bundle identifier.</string>
 	<key>uidata</key>
 	<dict>
 		<key>13F43189-880D-43E0-96D2-3F61F0094ABE</key>
@@ -485,7 +596,7 @@ The icon is provided under the [Creative Commons Attribution 3.0 Unported licenc
 			<key>note</key>
 			<string>Notification so you know what's been done</string>
 			<key>xpos</key>
-			<real>1220</real>
+			<real>1990</real>
 			<key>ypos</key>
 			<real>15</real>
 		</dict>
@@ -494,99 +605,124 @@ The icon is provided under the [Creative Commons Attribution 3.0 Unported licenc
 			<key>note</key>
 			<string>Choose whether or not to save resized image to clipboard</string>
 			<key>xpos</key>
-			<real>750</real>
+			<real>1520</real>
 			<key>ypos</key>
 			<real>120</real>
 		</dict>
-		<key>3DD4A818-A36E-430B-BAEC-EA019513C898</key>
+		<key>1F5758E6-F709-47A7-AAAF-4C5EA492F29C</key>
 		<dict>
 			<key>note</key>
-			<string>No deletion of original but a notification to confirm what you did</string>
+			<string>Final comfirmation of what has been done</string>
 			<key>xpos</key>
-			<real>1675</real>
+			<real>2210</real>
 			<key>ypos</key>
-			<real>270</real>
+			<real>145</real>
+		</dict>
+		<key>1F5DDD00-454A-4279-B8B4-E2C25763E34B</key>
+		<dict>
+			<key>xpos</key>
+			<real>475</real>
+			<key>ypos</key>
+			<real>105</real>
+		</dict>
+		<key>2B4BDF7E-0922-46B1-B5E9-F8EF143190A6</key>
+		<dict>
+			<key>note</key>
+			<string>Pass on tempFolder variable</string>
+			<key>xpos</key>
+			<real>585</real>
+			<key>ypos</key>
+			<real>45</real>
+		</dict>
+		<key>3E57E9FF-6F48-4C36-BB6E-088B3CBF86D6</key>
+		<dict>
+			<key>note</key>
+			<string>Pass on the file variable</string>
+			<key>xpos</key>
+			<real>885</real>
+			<key>ypos</key>
+			<real>45</real>
 		</dict>
 		<key>4FFD4BD5-3857-4901-A5EA-77938654A685</key>
 		<dict>
 			<key>note</key>
 			<string>Copy the original file to the default temp. folder set in User Configuration</string>
 			<key>xpos</key>
-			<real>305</real>
+			<real>1060</real>
 			<key>ypos</key>
 			<real>100</real>
 		</dict>
 		<key>5462DD99-202D-4CCF-9168-ACDE888A771D</key>
 		<dict>
 			<key>note</key>
-			<string>Save the file as a variable</string>
+			<string>Save the file as a variable &amp; carry through the temp folder variable</string>
 			<key>xpos</key>
-			<real>205</real>
+			<real>215</real>
 			<key>ypos</key>
-			<real>130</real>
+			<real>115</real>
+		</dict>
+		<key>5E27671A-7A50-4DAE-BA1E-B11661B50D57</key>
+		<dict>
+			<key>note</key>
+			<string>We are OK so pass on the file variable</string>
+			<key>xpos</key>
+			<real>725</real>
+			<key>ypos</key>
+			<real>170</real>
 		</dict>
 		<key>6D5054FE-1E88-4BDC-92FC-12AA858CF8E2</key>
 		<dict>
 			<key>note</key>
 			<string>Set file as input for next action</string>
 			<key>xpos</key>
-			<real>485</real>
+			<real>1255</real>
 			<key>ypos</key>
 			<real>130</real>
+		</dict>
+		<key>7F1CC430-1046-4A73-AEB0-D2E71CEB1D08</key>
+		<dict>
+			<key>note</key>
+			<string>Create the temp folder</string>
+			<key>xpos</key>
+			<real>690</real>
+			<key>ypos</key>
+			<real>15</real>
 		</dict>
 		<key>A447B8C8-13FB-4654-95B8-D2D837B08F8A</key>
 		<dict>
 			<key>note</key>
 			<string>Save resized image to clipboard</string>
 			<key>xpos</key>
-			<real>950</real>
+			<real>1720</real>
 			<key>ypos</key>
 			<real>15</real>
-		</dict>
-		<key>B94CD7E2-56D2-484C-9606-C96693CE37EB</key>
-		<dict>
-			<key>note</key>
-			<string>Browse in Alfred to delete original</string>
-			<key>xpos</key>
-			<real>1550</real>
-			<key>ypos</key>
-			<real>100</real>
 		</dict>
 		<key>B9C873E7-5CD9-48C1-A548-A8D1426FCF13</key>
 		<dict>
 			<key>note</key>
 			<string>Resize longest side of image to default length set in User Configuration</string>
 			<key>xpos</key>
-			<real>595</real>
+			<real>1365</real>
 			<key>ypos</key>
 			<real>100</real>
 		</dict>
-		<key>CD3C707E-E13B-4899-A98A-16B760CFD873</key>
+		<key>BBC10D8D-1F7A-423D-948C-B53AA74BD0D0</key>
 		<dict>
 			<key>note</key>
-			<string>Delete original file or not?</string>
+			<string>Check that the temp folder (see User Configuration) exists</string>
 			<key>xpos</key>
-			<real>1395</real>
+			<real>320</real>
 			<key>ypos</key>
-			<real>135</real>
+			<real>85</real>
 		</dict>
 		<key>D8C0109A-340F-49A4-ABDA-E948F55D9539</key>
 		<dict>
 			<key>note</key>
 			<string>Set file as input for next action (so we can use "Last path component” in the Notification Action)</string>
 			<key>xpos</key>
-			<real>1130</real>
+			<real>1900</real>
 			<key>ypos</key>
 			<real>45</real>
-		</dict>
-		<key>FE15CA00-F80F-42BC-88F8-D4AF594C231C</key>
-		<dict>
-			<key>note</key>
-			<string>Set file as input for next action (so we can use "Last path component” in the Notification Action)</string>
-			<key>xpos</key>
-			<real>1560</real>
-			<key>ypos</key>
-			<real>300</real>
 		</dict>
 		<key>FEF41243-ED09-4E03-8F13-CA50086D6E21</key>
 		<dict>
@@ -595,32 +731,11 @@ The icon is provided under the [Creative Commons Attribution 3.0 Unported licenc
 			<key>xpos</key>
 			<real>30</real>
 			<key>ypos</key>
-			<real>100</real>
+			<real>85</real>
 		</dict>
 	</dict>
 	<key>userconfigurationconfig</key>
 	<array>
-		<dict>
-			<key>config</key>
-			<dict>
-				<key>default</key>
-				<string>~/Downloads/Temp</string>
-				<key>placeholder</key>
-				<string>~/Downloads/Temp</string>
-				<key>required</key>
-				<true/>
-				<key>trim</key>
-				<true/>
-			</dict>
-			<key>description</key>
-			<string>This is the folder where the original image will be copied to preserve it. (You have the option of deleting the original at the end of the workflow.)</string>
-			<key>label</key>
-			<string>Temp folder to preserve original image</string>
-			<key>type</key>
-			<string>textfield</string>
-			<key>variable</key>
-			<string>tempFolder</string>
-		</dict>
 		<dict>
 			<key>config</key>
 			<dict>
@@ -642,11 +757,30 @@ The icon is provided under the [Creative Commons Attribution 3.0 Unported licenc
 			<key>variable</key>
 			<string>longestSide</string>
 		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
+				<string>/tmp/app.alfredapp.stephenc.resize.backups</string>
+				<key>filtermode</key>
+				<integer>1</integer>
+				<key>placeholder</key>
+				<string></string>
+				<key>required</key>
+				<false/>
+			</dict>
+			<key>description</key>
+			<string>The default backup location is deleted when macOS restarts.</string>
+			<key>label</key>
+			<string>Folder for backup of original</string>
+			<key>type</key>
+			<string>filepicker</string>
+			<key>variable</key>
+			<string>tempFolder</string>
+		</dict>
 	</array>
-	<key>variablesdontexport</key>
-	<array/>
 	<key>version</key>
-	<string>1.0</string>
+	<string>3.1</string>
 	<key>webaddress</key>
 	<string></string>
 </dict>


### PR DESCRIPTION
The purpose of the PR is to update the bundle identifier to `app.alfred.stephenc.resize`. Because bundle identifiers are supposed to follow a specific pattern following your domain name, we figured that `app.alfred.username.workflowname` is a good pattern for people who don’t have one. `com.alfredapp` is to be used in official workflows since it’s the official domain.

The `info.plist` in the repo was still for version 1, hence why it looks like there are so many changes. But from your released I’ve only changed the bundle identifier, the backups folder (to follow the same name), and the version (3.1, including adding to the changelog).